### PR TITLE
Update application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -31,5 +31,6 @@ module Arlab
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+    config.web_console.development_only = false
   end
 end


### PR DESCRIPTION
Update configuration to silence the following warning:

Web Console is activated in the test environment, which is
usually a mistake. To ensure it's only activated in development
mode, move it to the development group of your Gemfile:

    gem 'web-console', group: :development

If you still want to run it the test environment (and know
what you are doing), put this in your Rails application
configuration:

    config.web_console.development_only = false